### PR TITLE
replace mpif.h with use mpi

### DIFF
--- a/darts-suite/fortran/darts-collective.f
+++ b/darts-suite/fortran/darts-collective.f
@@ -1,8 +1,8 @@
 ! Compute pi using MPI collectives
         program darts
           use lcgenerator
+          use mpi
           implicit none
-          include 'mpif.h'
           integer :: num_trials = 1000000, i = 0, Ncirc = 0
           real :: pi = 0.0, x = 0.0, y = 0.0, r = 1.0
           real :: r2 = 0.0

--- a/darts-suite/fortran/darts-hybrid.f
+++ b/darts-suite/fortran/darts-hybrid.f
@@ -1,8 +1,8 @@
 ! Compute pi hybrid MPI/OpenMP
         program darts
           use lcgenerator
+          use mpi
           implicit none
-          include 'mpif.h'
           integer :: num_trials = 1000000, i = 0, Ncirc = 0
           real :: pi = 0.0, x = 0.0, y = 0.0, r = 1.0
           real :: r2 = 0.0

--- a/darts-suite/fortran/darts-mpi.f
+++ b/darts-suite/fortran/darts-mpi.f
@@ -1,8 +1,8 @@
 ! Compute pi using six basic MPI subroutines
         program darts
           use lcgenerator
+          use mpi
           implicit none
-          include 'mpif.h'
           integer :: num_trials = 1000000, i = 0, Ncirc = 0
           real :: pi = 0.0, x = 0.0, y = 0.0, r = 1.0
           real :: r2 = 0.0


### PR DESCRIPTION
`mpif.h` should not be used.

From the 3.1 standard 

> INCLUDE ’mpif.h’: This method is described in Section 17.1.4. The use of the include file mpif.h is strongly discouraged starting with MPI-3.0, because this method neither guarantees compile-time argument checking nor provides sufficient techniques to solve the optimization problems with nonblocking calls, and is therefore inconsistent with the Fortran standard. It exists only for backwards compatibility with legacy MPI applications.